### PR TITLE
Add HUIT cost allocation tags

### DIFF
--- a/jupyterhub_files/spawner.py
+++ b/jupyterhub_files/spawner.py
@@ -36,6 +36,9 @@ WORKER_TAGS = [ #These tags are set on every server created by the spawner
     {"Key": "Owner", "Value": SERVER_PARAMS["WORKER_SERVER_OWNER"]},
     {"Key": "Creator", "Value": SERVER_PARAMS["WORKER_SERVER_OWNER"]},
     {"Key": "Jupyter Cluster", "Value": SERVER_PARAMS["JUPYTER_CLUSTER"]},
+    {"Key": "environment", "Value": SERVER_PARAMS["ENVIRONMENT"]},
+    {"Key": "platform", "Value": SERVER_PARAMS["PLATFORM"]},
+    {"Key": "product", "Value": SERVER_PARAMS["JUPYTER_CLUSTER"]}
 ]
 
 #User data script to be executed on every worker created by the spawner

--- a/launch_cluster/instance_config.json
+++ b/launch_cluster/instance_config.json
@@ -9,5 +9,7 @@
 "REGION": "us-east-1",
 "WORKER_USERNAME": "ubuntu",
 "SERVER_OWNER": "",
-"IGNORE_PERMISSIONS": "false"
+"IGNORE_PERMISSIONS": "false",
+"ENVIRONMENT": "production",
+"PLATFORM": "linux"
 }

--- a/launch_cluster/launch.py
+++ b/launch_cluster/launch.py
@@ -71,6 +71,9 @@ def launch_manager(config):
         {"Key": "Owner", "Value": config.server_owner},
         {"Key": "Creator", "Value": config.server_owner},
         {"Key": "Jupyter Cluster", "Value": config.cluster_name},
+        {"Key": "platform", "Value": config.platform},
+        {"Key": "environment", "Value": config.environment},
+        {"Key": "product", "Value": config.cluster_name}
     ]
     instance.wait_until_exists()
     instance.wait_until_running()
@@ -106,6 +109,8 @@ def launch_manager(config):
         "JUPYTER_MANAGER_IP": instance.public_ip_address,
         "USER_HOME_EBS_SIZE": config.user_home_ebs_size,
         "MANAGER_IP_ADDRESS": str(instance.private_ip_address),
+        "ENVIRONMENT": config.environment,
+        "PLATFORM": config.platform
     }
 
     # Setup the common files and settings between manager and worker.


### PR DESCRIPTION
Tag manager and workers with 'platform', 'product', and 'environment' tags. These are required by HUIT, as specified [here](https://confluence.huit.harvard.edu/display/CLA/Cloud+Resource+Tagging#CloudResourceTagging-4.5%22platform%22Tag), for cost allocation. This change has been tested - see the tags of the manager and worker instance in the 'test-tagging' cluster. (The tagging of volumes and snapshots is 
not implemented here but in a separate PR in our gitlab jupyterhub repo). Let me know if you have any thoughts. Otherwise a thumbs up review is good enough here :).