### PR TITLE
Updated spawner logging to improve debugging and traceability.

### DIFF
--- a/jupyterhub_files/jupyterhub_config.py
+++ b/jupyterhub_files/jupyterhub_config.py
@@ -48,7 +48,7 @@ with open("/etc/jupyterhub/api_token.txt", 'r') as f:
     api_token = f.read().strip()
 c.JupyterHub.api_tokens = {api_token:"__tokengeneratoradmin"}
 
-c.Spawner.poll_interval = 10
+c.Spawner.poll_interval = 15
 c.Spawner.http_timeout = 300
 c.Spawner.start_timeout = 300
 

--- a/jupyterhub_files/spawner.py
+++ b/jupyterhub_files/spawner.py
@@ -247,7 +247,7 @@ class InstanceSpawner(Spawner):
                     yield self.kill_instance(instance)
                     return "Instance Hang"
                 else:
-                    notebook_running = yield self.is_notebook_running(instance.private_ip_address, attempts=1)
+                    notebook_running = yield self.is_notebook_running(instance.private_ip_address, attempts=3)
                     if notebook_running:
                         self.log_user("poll: notebook is running")
                         return None #its up!


### PR DESCRIPTION
This PR updates `spawner.py`. The changes are related to logging and checking whether a notebook is running.

When issues occur, it can be difficult to determine the cause since logging is a bit ad-hoc and has been added over time. The goal is to streamline the logging in such a way that it is easier to trace/debug spawner activity on a per user basis and make it possible to correlate the data with other metrics.

### Streamlining logging

- Added `self.log_user()` to the spawner, which automatically logs the user ID. By default, this will log an `INFO` message unless otherwise specified.
- Updated the existing logging messages to make it easier to trace the various asynchronous calls that are happening for every user. In particular, there's a lot of noise around the `poll()` function.

### Checking if a worker notebook is running on the server:

This change is slightly speculative, but given that the manager must SSH into every worker instance to verify that jupyter is running, the `is_notebook_running()` check should be as efficient as possible. 

Currently, we run  `ps -ef | grep jupyterhub-singleuser` which spawns 2 processes joined by a pipeline. That should work fine 99.999% of the time, but since we're seeing high loads when users are training their models, it might be worth switching to `nice -5 pgrep -a -f jupyterhub-singleuser`. This should be functionally equivalent, except that it executes one process with a slightly higher priority.

@joshuagetega @dodget 