### PR TITLE
Spawner upgrade fabric

### DIFF
--- a/jupyterhub_files/requirements_jupyterhub.txt
+++ b/jupyterhub_files/requirements_jupyterhub.txt
@@ -5,6 +5,7 @@ python-dateutil
 escapism
 cronutils
 fabric3
+fabric2==2.5.0
 pytz
 
 # optional; as needed for authentication

--- a/launch_cluster/requirements.txt
+++ b/launch_cluster/requirements.txt
@@ -1,4 +1,4 @@
 boto3
-fabric
+fabric2==2.5.0
 fabric3
-paramiko==2.4.0
+paramiko


### PR DESCRIPTION
This PR upgrades from [Fabric3 v1.14.post1](https://pypi.org/project/Fabric3/) to [Fabric v2.5](https://pypi.org/project/fabric/). The goal is to swap the old fabric `run()` and `sudo()` calls for the new ones, without changing the functionality.

The main [reason for upgrading](http://www.fabfile.org/upgrading.html#upgrading), is the fact that the latest version of fabric is _thread-safe_. This is important for the spawner, because fabric calls are submitted to a thread pool and executed asynchronously. It's not clear that the v1.x forked version of fabric is actually thread-safe, and some intermittent issues that have cropped up when the system is under load may be related to this.

**Additional Notes:**
- Fabric v2.x is a major rewrite, and the API has changed quite a bit. Thankfully, the [upgrade specifics documentation](http://www.fabfile.org/upgrading.html#upgrade-specifics) is very thorough.
- ~This is branched from `spawner-logging`. The expectation is that once `spawner-logging` has been merged into `develop`, then this PR can be updated so that the diff will show just the fabric-related updates.~
- I've tested this a little in in the miniconda cluster on the jupyterhub test site, but it needs more extensive testing to be sure it's working as expected.

**Upgrading:**

```
$ pip list | grep Fabric3           # Show that Fabric3==1.14.post1 is installed
$ pip install fabric2==2.5.0        # Install fabric v2.5.0 aliased to fabric2
```

I've used the name `fabric2` instead of plain old `fabric` intentionally (this is documented in the upgrade guide), that way we can be sure that an error will occur if fabric2 is not actually installed, and also so it can exist alongside code that has not been migrated yet (e.g. code still importing `fabric`).

@joshuagetega @dodget 
