### PR TITLE
Update 'whitelist' naming to 'allowed_users' as in JHub 1.2 change

### DIFF
--- a/jupyterhub_files/jupyterhub_config.py
+++ b/jupyterhub_files/jupyterhub_config.py
@@ -83,9 +83,9 @@ c.JupyterHub.authenticator_class	 = 'noauthenticator.NoAuthenticator'
 c.LocalAuthenticator.add_user_cmd	 = ['adduser', '-q', '--gecos', '""', '--disabled-password', '--force-badname']
 c.LocalAuthenticator.create_system_users = True
 
-# Add users to the admin list, the whitelist, and also record their user ids
+# Add users to the admin list, the allowed_users list, and also record their user ids
 c.Authenticator.admin_users	= admin		= set()
-c.Authenticator.whitelist	= whitelist	= set()
+c.Authenticator.allowed_users	= allowed_users	= set()
 if os.path.isfile('/etc/jupyterhub/userlist'):
     with open('/etc/jupyterhub/userlist') as f:
         for line in f:
@@ -93,7 +93,7 @@ if os.path.isfile('/etc/jupyterhub/userlist'):
                 continue
             parts = line.split()
             name = parts[0]
-            whitelist.add(name)
+            allowed_users.add(name)
             if len(parts) > 1 and parts[1] == 'admin':
                 admin.add(name)
 


### PR DESCRIPTION
This PR contains the following changes:

- Jhub 1.3 upgrade changes. Specifically, the whitelist was renamed to allowed_users as noted here. It is a breaking change without which worker instance launches fail.