### PR TITLE
Increase max_retries to 30 in create_new_instance

### DIFF
--- a/jupyterhub_files/spawner.py
+++ b/jupyterhub_files/spawner.py
@@ -434,6 +434,7 @@ class InstanceSpawner(Spawner):
                 SecurityGroupIds=SERVER_PARAMS["WORKER_SECURITY_GROUPS"],
                 BlockDeviceMappings=BDM,
                 UserData=user_data_script,
+                max_retries=30,
         )
         instance_id = reservation["Instances"][0]["InstanceId"]
         instance = yield retry(resource.Instance, instance_id)


### PR DESCRIPTION
This PR provides stopgap to hopefully stop unhandled errors in instance spawning